### PR TITLE
Add ISO date support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ $ npx create-security-txt --help
                       contact you about security issues. 
                       Remember to include "https://" for URLs,
                       and "mailto:" for e-mails.
-    --expires, -e     Expiration in days from now when the
-                      content of the security.txt file should
-                      be considered stale (so security
-                      researchers should then not trust
-                      it).
+    --expires, -e     Expiration in days from now or an ISO date
+                      string when the content of the security.txt file
+                      should be considered stale (so security
+                      researchers should then not trust it).
     --lang, -l        A language code that your security team
                       speaks.
     --canonical, -u   The URLs for accessing your security.txt

--- a/cli.js
+++ b/cli.js
@@ -11,10 +11,10 @@ const cli = meow(`
       --contact, -c     A link or e-mail address for people to contact
                         you about security issues. Remember to include
                         "https://" for URLs, and "mailto:" for e-mails.
-      --expires, -e     Expiration in days from now when the content of
-                        the security.txt file should be considered stale
-                        (so security researchers should then not trust
-                        it).
+      --expires, -e     Expiration in days from now or an ISO date
+                        string when the content of the security.txt file
+                        should be considered stale (so security
+                        researchers should then not trust it).
       --lang, -l        A language code that your security team speaks.
       --canonical, -u   The URLs for accessing your security.txt file.
                         It is important to include this if you are

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import meow from 'meow';
-import {addDays, formatRFC7231} from 'date-fns';
+import {parseISO, addDays, formatRFC7231} from 'date-fns';
 import flags from './flags.js';
 
 const cli = meow(`
@@ -67,9 +67,14 @@ if (cli.flags.contact.length === 0 || !cli.flags.expires) {
 			}
 
 			case 'expires': {
-				const now = new Date();
-				const expires = addDays(now, values);
-				return `${flagLabels[flag]}: ${formatRFC7231(expires)}`;
+				try {
+					const now = new Date();
+					const expires = typeof values === 'number' ? addDays(now, values) : parseISO(values);
+					return `${flagLabels[flag]}: ${formatRFC7231(expires)}`;
+				} catch {
+					cli.showHelp();
+					return null;
+				}
 			}
 
 			case 'lang': {

--- a/cli.test.js
+++ b/cli.test.js
@@ -72,3 +72,28 @@ test('Input with more than one preferred language', async t => {
 	t.regex(stdout, /Expires:\s(.+)\n/);
 	t.regex(stdout, /Preferred-Languages:\sen,\sfi/);
 });
+
+test('Input with "expires" as a numeric value', async t => {
+	const {stdout} = await execa('./cli.js', [
+		'--contact=itsec@acme.org',
+		'--expires=6',
+	]);
+	t.regex(stdout, /Expires:\s(.+)/);
+});
+
+test('Input with "expires" as an ISO date', async t => {
+	const date = '2080-08-01T15:00:00Z';
+	const {stdout} = await execa('./cli.js', [
+		'--contact=itsec@acme.org',
+		`--expires=${date}`,
+	]);
+	t.regex(stdout, /Expires:\s(\w+)/);
+});
+
+test('Input with an unparseable "expires" value shows help', async t => {
+	const {exitCode} = await t.throwsAsync(() => execa('./cli.js', [
+		'-c itsec@acme.org',
+		'-e FAIL',
+	]));
+	t.is(exitCode, 2);
+});

--- a/flags.js
+++ b/flags.js
@@ -7,7 +7,6 @@ const flags = {
 	},
 	expires: {
 		label: 'Expires',
-		type: 'number',
 		alias: 'e',
 	},
 	lang: {


### PR DESCRIPTION
Allow either a relative numeric value or an ISO date string as values for the `--expires` flag:

1. `--expires 20` sets an expiration date 20 days from now
2. `--expires 2022-07-30T00:00:00Z` sets July 7th, 2022 at 12am GMT as the expiration date