### PR TITLE
Change expiration format to ISO8601

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import meow from 'meow';
-import {parseISO, addDays, formatISO} from 'date-fns';
+import {parseISO, addDays} from 'date-fns';
 import flags from './flags.js';
 
 const cli = meow(`
@@ -70,7 +70,7 @@ if (cli.flags.contact.length === 0 || !cli.flags.expires) {
 				try {
 					const now = new Date();
 					const expires = typeof values === 'number' ? addDays(now, values) : parseISO(values);
-					return `${flagLabels[flag]}: ${formatISO(expires)}`;
+					return `${flagLabels[flag]}: ${expires.toISOString()}`;
 				} catch {
 					cli.showHelp();
 					return null;

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import meow from 'meow';
-import {parseISO, addDays, formatRFC7231} from 'date-fns';
+import {parseISO, addDays, formatISO} from 'date-fns';
 import flags from './flags.js';
 
 const cli = meow(`
@@ -70,7 +70,7 @@ if (cli.flags.contact.length === 0 || !cli.flags.expires) {
 				try {
 					const now = new Date();
 					const expires = typeof values === 'number' ? addDays(now, values) : parseISO(values);
-					return `${flagLabels[flag]}: ${formatRFC7231(expires)}`;
+					return `${flagLabels[flag]}: ${formatISO(expires)}`;
 				} catch {
 					cli.showHelp();
 					return null;


### PR DESCRIPTION
This PR fixes #186 by using `.toISOString()` to format the date to ISO8601. Initially it used the `formatISO()`-function, but I was unsure the `+00:00` timezone offset would be accepted by security.txt.

I ran the CLI locally along with all the tests with a 100% pass.